### PR TITLE
Use avi-lbaas endpoint for Avi Controller

### DIFF
--- a/rocky-docker/install_scripts/setup-avi-heat
+++ b/rocky-docker/install_scripts/setup-avi-heat
@@ -8,7 +8,7 @@ git checkout $HEAT_BRANCH
 python setup.py sdist
 pip install dist/*tar.gz
 
-sed -i 's/avi_controller=/avi_controller='"$AVI_IP"'/' /etc/heat/heat.conf
+# sed -i 's/avi_controller=/avi_controller='"$AVI_IP"'/' /etc/heat/heat.conf
 sed -i '1 a plugin_dirs = "/usr/local/lib/python2.7/dist-packages/avi/heat"' /etc/heat/heat.conf
 
 pkill -9 heat-engine


### PR DESCRIPTION
In Avi Heat Plugin, we identify the Avi Controller IP from (a) avi-lbaas endpoint or (b) user sets the avi_controller field in heat.conf.
In our tests, we are testing with heat.conf. However, there are customers using avi-lbaas endpoint to pass the Avi Controller IP, we should test it.

There was a recent fix in this area: https://github.com/avinetworks/avi-heat/pull/44
Having a test to make sure the fix works fine.